### PR TITLE
pref👷action GitHub `set-output` 过时警告

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -30,8 +30,8 @@ jobs:
         working-directory: ./actions/stepper
         run: |
           go run -v ./...
-          echo "::set-output name=fileName::$(cat download_filename)"
-          echo "::set-output name=url::$(cat download_url)"
+          echo "fileName=${cat download_filename}" >> $GITHUB_OUTPUT
+          echo "url=${cat download_url}" >> $GITHUB_OUTPUT
           rm -f download_filename
           rm -f download_url
 


### PR DESCRIPTION
解决 set-output [过时警告](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)