### PR TITLE
PREF⬆️ 最低支持 Rust 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "senjuko-conch"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.67"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
变更最低支持的 Rust 版本为 1.67